### PR TITLE
Improve panic message reporting.

### DIFF
--- a/cc3200-sys/board.c
+++ b/cc3200-sys/board.c
@@ -27,9 +27,27 @@ extern uint32_t _ebss;
 // start is written in rust
 void start(void);
 
+typedef struct
+{
+  volatile uint32_t DHCSR;  /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+  volatile uint32_t DCRSR;  /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+  volatile uint32_t DCRDR;  /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+  volatile uint32_t DEMCR;  /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+} CoreDebug_Type;
+
+#define CoreDebug_BASE      (0xE000EDF0UL)                            /*!< Core Debug Base Address */
+#define CoreDebug           ((CoreDebug_Type *)     CoreDebug_BASE)   /*!< Core Debug configuration struct */
+
+int is_debugger_running(void) {
+    return (CoreDebug->DHCSR & 1) != 0; // Bit 0 is DEBUGEN
+}
+
 void reset(void)
 {
-  PRCMMCUReset(1);
+    if (is_debugger_running()) {
+        __asm volatile ("bkpt #0");
+    }
+    PRCMMCUReset(1);
 }
 
 __attribute__((naked))

--- a/cc3200-sys/board.c
+++ b/cc3200-sys/board.c
@@ -27,6 +27,11 @@ extern uint32_t _ebss;
 // start is written in rust
 void start(void);
 
+void reset(void)
+{
+  PRCMMCUReset(1);
+}
+
 __attribute__((naked))
 void isr_reset(void)
 {

--- a/cc3200-sys/board.h
+++ b/cc3200-sys/board.h
@@ -2,4 +2,4 @@ void board_init(void);
 void console_putchar(char ch);
 void console_puts(const char *s);
 void print_reg(const char *label, uint32_t val);
-
+void reset(void);

--- a/cc3200-sys/src/lib.rs
+++ b/cc3200-sys/src/lib.rs
@@ -12,6 +12,7 @@ extern "C" {
     // From board.c
     pub fn board_init();
     pub fn console_putchar(char: i8);
+    pub fn reset();
 
     // From sdk/examples/common/gpio_if.c
     pub fn GPIO_IF_LedConfigure(pins: u8);

--- a/example/blinky.rs
+++ b/example/blinky.rs
@@ -39,6 +39,8 @@ pub fn start() -> ! {
     Console::clear_term();
     println!("Welcome to CC3200 blinking leds version {}", VERSION);
 
+    assert_eq!(1, 2);
+
     let queue = Arc::new(Queue::new(10).unwrap());
     let _producer = {
         let queue = queue.clone();

--- a/src/cc3200.rs
+++ b/src/cc3200.rs
@@ -70,6 +70,14 @@ impl Board {
             cc3200_sys::vTaskStartScheduler();
         }
     }
+
+    pub fn disable_irq() {
+        unsafe { asm!("cpsid i"); }
+    }
+
+    pub fn reset() {
+        unsafe { cc3200_sys::reset(); }
+    }
 }
 
 pub struct Console { }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ extern crate cc3200_sys;
 pub mod cc3200;
 pub mod isr_vectors;
 
-// These functions are used by the compiler, but not  are normally provided by libstd.
+// These functions are used by the compiler, but are normally provided by libstd.
 #[allow(private_no_mangle_fns)]
 mod lang_items {
     use core::fmt::Arguments;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,15 +10,34 @@
 
 extern crate cc3200_sys;
 
+#[macro_use]
 pub mod cc3200;
 pub mod isr_vectors;
 
-// We need to define the panic_fmt "lang item", which is just a function. This specifies
-// what the program should do when a `panic!` occurs. Our program won't panic, so we can leave the
-// function body empty for now.
+// These functions are used by the compiler, but not  are normally provided by libstd.
+#[allow(private_no_mangle_fns)]
 mod lang_items {
+    use core::fmt::Arguments;
+
+    #[lang = "eh_personality"]
+    #[no_mangle]
+    pub extern fn rust_eh_personality() {
+    }
+
+    // This function may be needed based on the compilation target.
+    #[lang = "eh_unwind_resume"]
+    #[no_mangle]
+    pub extern fn rust_eh_unwind_resume() {
+    }
+
     #[lang = "panic_fmt"]
-    extern "C" fn panic_fmt() {}
+    #[no_mangle]
+    pub extern fn rust_begin_panic(_msg: Arguments,
+                                   _file: &'static str,
+                                   _line: u32) -> ! {
+        println!("Panic at {}:{} : {}", _file, _line, _msg);
+        loop {}
+    }
 }
 
 // Needed in debug builds to not get this linking error:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod isr_vectors;
 #[allow(private_no_mangle_fns)]
 mod lang_items {
     use core::fmt::Arguments;
+    use cc3200::{Board, LedEnum, LedName, Utils};
 
     #[lang = "eh_personality"]
     #[no_mangle]
@@ -36,6 +37,27 @@ mod lang_items {
                                    _file: &'static str,
                                    _line: u32) -> ! {
         println!("Panic at {}:{} : {}", _file, _line, _msg);
+
+        // Disable irqs.
+        Board::disable_irq();
+
+        // Configure the LEDs in case it's not done by the application and blink them.
+        Board::led_configure(&[LedEnum::LED1, LedEnum::LED2, LedEnum::LED3]);
+        for _ in 0..4 {
+            Board::led_off(LedName::MCU_RED_LED_GPIO);
+            Board::led_off(LedName::MCU_ORANGE_LED_GPIO);
+            Board::led_off(LedName::MCU_GREEN_LED_GPIO);
+            Utils::delay(1000000);
+            Board::led_on(LedName::MCU_RED_LED_GPIO);
+            Board::led_on(LedName::MCU_ORANGE_LED_GPIO);
+            Board::led_on(LedName::MCU_GREEN_LED_GPIO);
+            Utils::delay(1000000);
+        }
+
+        // Reset the processor.
+        Board::reset();
+
+        // Just please the Rust compiler which expects a divergent function.
         loop {}
     }
 }


### PR DESCRIPTION
That prints:
Panic at example/blinky.rs:42 : assertion failed: `(left == right)` (left: `1`, right: `2`)
when hitting assert_eq!(1, 2)

r? @dhylands 

Will fix https://github.com/mozilla-sensorweb/sensorweb-firmware/issues/8