### PR TITLE
Logging support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ name = "cc3200"
 cc3200-sys = { path = "cc3200-sys" }
 freertos_alloc = { path = "freertos_alloc" }
 freertos_rs = "0.1"
+log = { version = "0.3", default-features = false }
 
 [[example]]
 name = "blinky"

--- a/example/blinky.rs
+++ b/example/blinky.rs
@@ -15,6 +15,8 @@ extern crate cc3200;
 extern crate alloc;
 extern crate freertos_rs;
 extern crate freertos_alloc;
+#[macro_use]
+extern crate log;
 
 use cc3200::cc3200::{Board, Console, Utils, LedEnum, LedName};
 
@@ -37,7 +39,7 @@ pub fn start() -> ! {
 
     Console::init_term();
     Console::clear_term();
-    println!("Welcome to CC3200 blinking leds version {}", VERSION);
+    info!("Welcome to CC3200 blinking leds version {}", VERSION);
 
     Board::test();
 

--- a/src/cc3200.rs
+++ b/src/cc3200.rs
@@ -7,6 +7,7 @@ extern crate cc3200_sys;
 use core;
 use self::cc3200_sys::{board_init, GPIO_IF_LedConfigure, GPIO_IF_LedOn, GPIO_IF_LedOff,
                        MAP_UtilsDelay};
+use logger::SimpleLogger;
 
 #[allow(non_camel_case_types, dead_code)]
 pub enum LedName {
@@ -38,6 +39,7 @@ pub struct Board { }
 
 impl Board {
     pub fn init() {
+        SimpleLogger::init().unwrap();
         unsafe {
             board_init();
         }
@@ -123,24 +125,6 @@ impl core::fmt::Write for Console {
         Console::message(s);
         Ok(())
     }
-}
-
-#[macro_export]
-macro_rules! print {
-    ($($args:tt)*) => {
-        // Ignore logging errors. It's not worth killing the program because of
-        // failed debug output. It would be nicer to save the error and report
-        // it later, however.
-        use core::fmt::Write;
-        let mut console = $crate::cc3200::Console {};
-        let _ = write!(console, $($args)*);
-    }
-}
-
-#[macro_export]
-macro_rules! println {
-    ($fmt:expr)               => ( print!(concat!($fmt, '\n')) );
-    ($fmt:expr, $($args:tt)*) => ( print!(concat!($fmt, '\n'), $($args)*) );
 }
 
 pub struct Utils { }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,11 @@
 #![feature(asm, lang_items)]
 
 extern crate cc3200_sys;
+#[macro_use]
+extern crate log;
 
 #[macro_use]
+pub mod logger;
 pub mod cc3200;
 pub mod isr_vectors;
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// A simple logger that sets the max log level to Trace in debug builds and to Info in release ones.
+
+use log::{self, LogRecord, LogLevelFilter, LogMetadata, SetLoggerError};
+
+#[macro_export]
+macro_rules! print {
+    ($($args:tt)*) => {
+        // Ignore logging errors. It's not worth killing the program because of
+        // failed debug output. It would be nicer to save the error and report
+        // it later, however.
+        use core::fmt::Write;
+        let mut console = $crate::cc3200::Console {};
+        let _ = write!(console, $($args)*);
+    }
+}
+
+#[macro_export]
+macro_rules! println {
+    ($fmt:expr)               => ( print!(concat!($fmt, '\n')) );
+    ($fmt:expr, $($args:tt)*) => ( print!(concat!($fmt, '\n'), $($args)*) );
+}
+
+pub struct SimpleLogger;
+
+#[cfg(debug_assertions)]
+static MAX_LOG_LEVEL: LogLevelFilter = LogLevelFilter::Trace;
+
+#[cfg(not(debug_assertions))]
+static MAX_LOG_LEVEL: LogLevelFilter = LogLevelFilter::Info;
+
+impl log::Log for SimpleLogger {
+    fn enabled(&self, metadata: &LogMetadata) -> bool {
+        return metadata.level() <= MAX_LOG_LEVEL;
+    }
+
+    fn log(&self, record: &LogRecord) {
+        if self.enabled(record.metadata()) {
+            println!("{:5} [{}@{}] {}",
+                     record.level(),
+                     record.target(),
+                     record.location().line(),
+                     record.args());
+        }
+    }
+}
+
+impl SimpleLogger {
+    pub fn init() -> Result<(), SetLoggerError> {
+        println!("Logger level is {}", MAX_LOG_LEVEL);
+        unsafe {
+            log::set_logger_raw(|max_log_level| {
+                max_log_level.set(MAX_LOG_LEVEL);
+                &SimpleLogger
+            })
+        }
+    }
+}


### PR DESCRIPTION
This sets the log level to `Trace` in debug builds and to `Info` for release builds. If we need we could add a way to force the exact level we want with a feature.

Example output:
INFO  [blinky@42] Welcome to CC3200 blinking leds version 1.0