### PR TITLE
Add common-build crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ build = "build.rs"
 [lib]
 name = "cc3200"
 
+[build-dependencies]
+common-build = { path = "common-build" }
+
 [dependencies]
 cc3200-sys = { path = "cc3200-sys" }
 freertos_alloc = { path = "freertos_alloc" }

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,9 @@
+extern crate common_build;
+
 use std::path::Path;
-use std::process::Command;
 
 fn get_lib(opt: &str) -> String {
-    let libgcc = Command::new("arm-none-eabi-gcc")
-        .arg("-mthumb")
-        .arg("-mcpu=cortex-m4")
-        .arg("-mfloat-abi=soft")
+    let libgcc = common_build::gcc_config().get_compiler().to_command()
         .arg(opt)
         .output()
         .unwrap();

--- a/cc3200-sys/Cargo.toml
+++ b/cc3200-sys/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Dave Hylands <dhylands@gmail.com>"]
 build = "build.rs"
 
 [build-dependencies]
-gcc = "0.3"
+common-build = { path = "../common-build" }

--- a/cc3200-sys/build.rs
+++ b/cc3200-sys/build.rs
@@ -1,9 +1,6 @@
-extern crate gcc;
+extern crate common_build;
 fn main() {
-    gcc::Config::new()
-        .compiler("arm-none-eabi-gcc")
-        .define("gcc", None)
-        .define("USE_FREERTOS", None)
+    common_build::gcc_config()
         .include(".")
         .include("sdk")
         .include("sdk/inc")
@@ -12,10 +9,6 @@ fn main() {
         .include("sdk/oslib")
         .include("sdk/third_party/FreeRTOS/source/include")
         .include("sdk/third_party/FreeRTOS/source/portable/GCC/ARM_CM4")
-        .flag("-std=c99")
-        .flag("-mthumb")
-        .flag("-mcpu=cortex-m4")
-        .flag("-mfloat-abi=soft")
         .file("board.c")
         .file("StrPrintf.c")
         .file("freertos_rs.c")

--- a/common-build/Cargo.toml
+++ b/common-build/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "common-build"
+version = "0.1.0"
+authors = ["Dave Hylands <dhylands@gmail.com>"]
+
+[dependencies]
+gcc = "0.3"

--- a/common-build/src/lib.rs
+++ b/common-build/src/lib.rs
@@ -1,0 +1,18 @@
+extern crate gcc;
+
+// Various crates need to ensure that they all use the same compiler options,
+// so this crate provides a function that returns a gcc::Config object with
+// all of the "must have" options already set.
+
+pub fn gcc_config() -> gcc::Config {
+    let mut config = gcc::Config::new();
+    config.compiler("arm-none-eabi-gcc")
+        .define("gcc", None)
+        .define("USE_FREERTOS", None)
+        .define("SL_PLATFORM_MULTI_THREADED", None)
+        .flag("-std=c99")
+        .flag("-mthumb")
+        .flag("-mcpu=cortex-m4")
+        .flag("-mfloat-abi=soft");
+    config
+}

--- a/freertos_alloc/Cargo.toml
+++ b/freertos_alloc/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Dave Hylands <dhylands@gmail.com>"]
 build = "build.rs"
 
 [build-dependencies]
-gcc = "0.3"
+common-build = { path = "../common-build" }

--- a/freertos_alloc/build.rs
+++ b/freertos_alloc/build.rs
@@ -1,13 +1,6 @@
-extern crate gcc;
+extern crate common_build;
 fn main() {
-  gcc::Config::new()
-    .compiler("arm-none-eabi-gcc")
-    .define("gcc", None)
-    .flag("-fno-exceptions")
-    .flag("-mthumb")
-    .flag("-mcpu=cortex-m4")
-    .flag("-mfloat-abi=softfp")
-    .flag("-mfpu=fpv4-sp-d16")
+  common_build::gcc_config()
     .include("../cc3200-sys")
     .include("../cc3200-sys/sdk/third_party/FreeRTOS/source/include")
     .include("../cc3200-sys/sdk/third_party/FreeRTOS/source/portable/GCC/ARM_CM4")


### PR DESCRIPTION
This encapsulates all of the common cross compiler command line
options into one place.