### PR TITLE
Add format_float_into and format_int_into routines written in rust.

### DIFF
--- a/examples/format_into.rs
+++ b/examples/format_into.rs
@@ -1,0 +1,133 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// We won't use the usual `main` function. We are going to use a different "entry point".
+#![no_main]
+
+// We won't use the standard library because it requires OS abstractions like threads and files and
+// those are not available in this platform.
+#![no_std]
+#![feature(alloc)]
+#![feature(collections)]
+
+#[macro_use]
+extern crate cc3200;
+extern crate alloc;
+extern crate freertos_rs;
+extern crate freertos_alloc;
+
+use cc3200::cc3200::Board;
+use freertos_rs::Task;
+
+#[macro_use]
+extern crate collections;
+
+use core::str;
+use collections::string::String;
+
+use cc3200::format::{format_int_into, format_float_into};
+
+fn buf_find(buf: &[u8], needle: &str) -> Option<usize> {
+    if let Ok(s) = str::from_utf8(buf) {
+        s.find(needle)
+    } else {
+        None
+    }
+}
+
+fn test_int_fill(num: i32, fill: char) {
+    let mut buf: [u8; 32] = ['@' as u8; 32];
+
+    let tmpl = b"Num: >99999<";
+    let num_tmpl = "99999";
+
+    buf[0..tmpl.len()].copy_from_slice(tmpl);
+
+    let num_idx = buf_find(&buf, num_tmpl).unwrap();
+
+    format_int_into(&mut buf[num_idx..num_idx + num_tmpl.len()], num, fill);
+
+    println!("{}", String::from_utf8_lossy(&buf[0..tmpl.len()]));
+}
+
+fn test_int(num: i32) {
+    test_int_fill(num, ' ');
+    test_int_fill(num, '0');
+}
+
+fn test_float(num: f64, digits_after_decimal: u32) {
+    let mut buf: [u8; 32] = ['@' as u8; 32];
+
+    let tmpl = b"Num: >99999.99<";
+    let num_tmpl = "99999.99";
+
+    buf[0..tmpl.len()].copy_from_slice(tmpl);
+
+    let num_idx = buf_find(&buf, num_tmpl).unwrap();
+
+    format_float_into(&mut buf[num_idx..num_idx + num_tmpl.len()],
+                      num,
+                      digits_after_decimal);
+
+    println!("{}", String::from_utf8_lossy(&buf[0..tmpl.len()]));
+}
+
+fn test_main() {
+    let test_ints = vec![123456, 12345, 1234, 123, 12, 1, 0, -1, -12, -123, -1234, -12345, -123456];
+
+    for test_i in test_ints.iter() {
+        test_int(*test_i);
+    }
+
+    let test_floats = vec![123456.7890,
+                           12345.6789,
+                           1234.5678,
+                           123.4567,
+                           12.3456,
+                           1.2345,
+                           1.0000,
+                           0.9999,
+                           0.1000,
+                           0.0000,
+                           -0.1000,
+                           -0.9999,
+                           -1.0000,
+                           -1.2345,
+                           -12.3456,
+                           -123.4567,
+                           -1234.5678,
+                           -12345.6789];
+
+    for test_f in test_floats.iter() {
+        test_float(*test_f, 2);
+    }
+}
+
+// Conceptually, this is our program "entry point". It's the first thing the microcontroller will
+// execute when it (re)boots. (As far as the linker is concerned the entry point must be named
+// `start` (by default; it can have a different name). That's why this function is `pub`lic, named
+// `start` and is marked as `#[no_mangle]`.)
+//
+// Returning from this function is undefined because there is nothing to return to! To statically
+// forbid returning from this function, we mark it as divergent, hence the `fn() -> !` signature.
+#[no_mangle]
+pub fn start() -> ! {
+    Board::init();
+
+    let _blinky = {
+        Task::new()
+            .name("blinky")
+            .start(|| {
+                test_main();
+            })
+            .unwrap()
+    };
+
+    Board::start_scheduler();
+
+    // The only reason start_scheduler should fail is if there wasn't enough
+    // heap to initialize the IDLE and timer tasks
+
+    loop {}
+}

--- a/examples/format_into.rs
+++ b/examples/format_into.rs
@@ -46,9 +46,11 @@ fn test_int_fill(num: i32, fill: char) {
 
     let num_idx = buf_find(&buf, num_tmpl).unwrap();
 
-    format_int_into(&mut buf[num_idx..num_idx + num_tmpl.len()], num, fill);
-
-    println!("{}", String::from_utf8_lossy(&buf[0..tmpl.len()]));
+    if format_int_into(&mut buf[num_idx..num_idx + num_tmpl.len()], num, fill) {
+        println!("{}", String::from_utf8_lossy(&buf[0..tmpl.len()]));
+    } else {
+        println!("*** overflow ***");
+    }
 }
 
 fn test_int(num: i32) {
@@ -66,11 +68,13 @@ fn test_float(num: f64, digits_after_decimal: u32) {
 
     let num_idx = buf_find(&buf, num_tmpl).unwrap();
 
-    format_float_into(&mut buf[num_idx..num_idx + num_tmpl.len()],
-                      num,
-                      digits_after_decimal);
-
-    println!("{}", String::from_utf8_lossy(&buf[0..tmpl.len()]));
+    if format_float_into(&mut buf[num_idx..num_idx + num_tmpl.len()],
+                         num,
+                         digits_after_decimal) {
+        println!("{}", String::from_utf8_lossy(&buf[0..tmpl.len()]));
+    } else {
+        println!("*** overflow ***");
+    }
 }
 
 fn test_main() {

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,212 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+extern crate core;
+
+use core::cmp::min;
+
+pub fn fill_buf(buf: &mut [u8], fill_byte: u8) {
+    for ch in buf.iter_mut() {
+        *ch = fill_byte;
+    }
+}
+
+pub fn format_int_into(buf: &mut [u8], num: i32, fill: char) {
+    let mut overflow = false;
+    if buf.len() < 1 {
+        return;
+    }
+
+    // Introduce a block so that we limit the lifetime of the borrow (of buf)
+    // otherwise we can't do the overflow fill at the end of the function.
+    {
+        let digit: &'static [u8; 10] = b"0123456789";
+        let mut abs_num = num.abs();
+
+        // Write the digits into the buffer from right to left
+        let mut buf_iter = buf.iter_mut().rev();
+        if abs_num == 0 {
+            if let Some(ch) = buf_iter.next() {
+                *ch = b'0';
+            }
+        } else {
+            while abs_num > 0 {
+                if let Some(ch) = buf_iter.next() {
+                    *ch = digit[(abs_num % 10) as usize];
+                    abs_num /= 10;
+                } else {
+                    overflow = true;
+                    break;
+                }
+            }
+        }
+        if fill == ' ' {
+            if num < 0 {
+                // When using a space fill, the sign goes next
+                // to the last digit
+                if let Some(ch) = buf_iter.next() {
+                    *ch = b'-';
+                } else {
+                    overflow = true;
+                }
+            }
+            // Space fill
+            while let Some(ch) = buf_iter.next() {
+                *ch = b' ';
+            }
+        } else {
+            // non-space fill on the left.
+            while let Some(ch) = buf_iter.next() {
+                *ch = fill as u8;
+            }
+        }
+    }
+    if num < 0 && fill != ' ' {
+        // Special case for non-space fill and negative numbers. We'll
+        // overwrite the leftmost fill character with the sign.
+        if buf[0] == (fill as u8) {
+            buf[0] = b'-';
+        } else {
+            overflow = true;
+        }
+    }
+    if overflow {
+        // If we overflowed then fill the entire field with stars.
+        fill_buf(buf, b'*');
+    }
+}
+
+pub fn format_float_into(buf: &mut [u8], num: f64, digits_after_decimal: u32) {
+    let buf_len = buf.len();
+
+    let mut factor = 1;
+    for _ in 0..digits_after_decimal {
+        factor *= 10;
+    }
+    let mut num = num * factor as f64;
+    if num < 0.0 {
+        num -= 0.5;
+    } else {
+        num += 0.5
+    }
+    let num_as_int: i32 = num as i32;
+
+    let num_before_decimal = num_as_int / factor;
+    let num_after_decimal = num_as_int.abs() % factor;
+
+    let digits_after_decimal = min(buf_len - 2, digits_after_decimal as usize);
+    let digits_before_decimal = buf_len - digits_after_decimal - 1; // -1 for decimal point
+
+    if num_as_int < 0 && num_as_int > -factor {
+        // numbers between 0 and -1 need to be treated specially since we need
+        // to have num_before_decimal be -0
+        format_int_into(&mut buf[0..digits_before_decimal], 0, ' ');
+        buf[digits_before_decimal - 2] = b'-';
+    } else {
+        format_int_into(&mut buf[0..digits_before_decimal], num_before_decimal, ' ');
+    }
+    if buf[0] == b'*' {
+        // Integer portion overflowed. Overflow the whole thing.
+        fill_buf(buf, b'*');
+    } else {
+        buf[digits_before_decimal] = b'.';
+        format_int_into(&mut buf[digits_before_decimal + 1..buf_len],
+                        num_after_decimal,
+                        '0');
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use ::*;
+
+    fn format_int_into_ref(buf: &mut [u8], num: i32, fill: char) {
+
+        let s = if fill == '0' {
+            format!("{:01$}", num, buf.len())
+        } else {
+            format!("{:1$}", num, buf.len())
+        };
+        let s_len = s.len();
+        let buf_len = buf.len();
+
+        // The width parameter is a minimum, but our buffer is constrained.
+        // So we copy the rightmost buf_len characters.
+        if s_len > buf_len {
+            // Number didn't fit
+            fill_buf(buf, b'*');
+        } else {
+            buf.copy_from_slice(&(s.into_bytes())[0..buf_len]);
+        }
+    }
+
+    #[test]
+    fn test_int() {
+        let test_nums = vec![123456, 12345, 1234, 123, 12, 1, 0, -1, -12, -123, -1234, -12345,
+                             -123456];
+
+        let mut int_buf: [u8; 5] = [0; 5];
+        let mut ref_buf: [u8; 5] = [0; 5];
+
+        for num in test_nums.iter() {
+            format_int_into(&mut int_buf[..], *num, ' ');
+            format_int_into_ref(&mut ref_buf[..], *num, ' ');
+
+            assert_eq!(int_buf, ref_buf);
+        }
+
+        for num in test_nums.iter() {
+            format_int_into(&mut int_buf[..], *num, '0');
+            format_int_into_ref(&mut ref_buf[..], *num, '0');
+
+            assert_eq!(int_buf, ref_buf);
+        }
+    }
+
+    fn format_float_into_ref(buf: &mut [u8], num: f64, digits_after_decimal: u32) {
+        let buf_len = buf.len();
+        let s = format!("{0:1$.2$}", num, buf_len, digits_after_decimal as usize);
+        let s_len = s.len();
+
+        if s_len > buf_len {
+            // Number didn't fit
+            fill_buf(buf, b'*');
+        } else {
+            buf.copy_from_slice(&(s.into_bytes())[0..buf_len]);
+        }
+    }
+
+    #[test]
+    fn test_float() {
+        let test_floats = vec![123456.7890,
+                               12345.6789,
+                               1234.5678,
+                               123.4567,
+                               12.3456,
+                               1.2345,
+                               1.0000,
+                               0.9999,
+                               0.1000,
+                               0.0000,
+                               -0.1000,
+                               -0.9999,
+                               -1.0000,
+                               -1.2345,
+                               -12.3456,
+                               -123.4567,
+                               -1234.5678,
+                               -12345.6789];
+
+        let mut int_buf: [u8; 8] = [0; 8];
+        let mut ref_buf: [u8; 8] = [0; 8];
+
+        for num in test_floats.iter() {
+            format_float_into(&mut int_buf[..], *num, 2);
+            format_float_into_ref(&mut ref_buf[..], *num, 2);
+
+            assert_eq!(int_buf, ref_buf);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod logger;
 pub mod cc3200;
 pub mod i2c_devices;
 pub mod isr_vectors;
+pub mod format;
 
 pub mod bma222;
 pub mod tmp006;


### PR DESCRIPTION
Here's a pair of formatting routines.

If you run the example format_into.rs then I get the following output:
```
Num: >*****<
Num: >*****<
Num: >12345<
Num: >12345<
Num: > 1234<
Num: >01234<
Num: >  123<
Num: >00123<
Num: >   12<
Num: >00012<
Num: >    1<
Num: >00001<
Num: >    0<
Num: >00000<
Num: >   -1<
Num: >-0001<
Num: >  -12<
Num: >-0012<
Num: > -123<
Num: >-0123<
Num: >-1234<
Num: >-1234<
Num: >*****<
Num: >*****<
Num: >*****<
Num: >*****<
Num: >********<
Num: >12345.68<
Num: > 1234.57<
Num: >  123.46<
Num: >   12.35<
Num: >    1.23<
Num: >    1.00<
Num: >    1.00<
Num: >    0.10<
Num: >    0.00<
Num: >   -0.10<
Num: >   -1.00<
Num: >   -1.00<
Num: >   -1.23<
Num: >  -12.35<
Num: > -123.46<
Num: >-1234.57<
Num: >********<
```

There are also some tests. I haven't been able to get the tests to work inside this crate, but they worked in a standalone crate.