### PR TITLE
Fix call to wlan_connect

### DIFF
--- a/src/simplelink.rs
+++ b/src/simplelink.rs
@@ -133,8 +133,8 @@ impl SimpleLink {
         let ssid_len = ssid.len() as i16;
         let mac_addr_len = mac_addr.len();
         let mac_addr_ptr = if mac_addr_len > 0 { mac_addr.as_ptr() } else { ptr::null() as *const u8 };
-        let sec_params_ptr: *const SlSecParams = sec_params.map(|r| &r as *const SlSecParams).unwrap_or(ptr::null() as *const SlSecParams);
-        let sec_params_ext_ptr: *const SlSecParamsExt = sec_params_ext.map(|r| &r as *const SlSecParamsExt).unwrap_or(ptr::null() as *const SlSecParamsExt);
+        let sec_params_ptr: *const SlSecParams = sec_params.as_ref().map(|r| r as *const SlSecParams).unwrap_or(ptr::null() as *const SlSecParams);
+        let sec_params_ext_ptr: *const SlSecParamsExt = sec_params_ext.as_ref().map(|r| r as *const SlSecParamsExt).unwrap_or(ptr::null() as *const SlSecParamsExt);
         try_wlan!(sl_WlanConnect(ssid_ptr, ssid_len, mac_addr_ptr, sec_params_ptr, sec_params_ext_ptr));
         Ok(())
     }

--- a/src/simplelink.rs
+++ b/src/simplelink.rs
@@ -132,9 +132,9 @@ impl SimpleLink {
         let ssid_ptr = ssid.as_ptr();
         let ssid_len = ssid.len() as i16;
         let mac_addr_len = mac_addr.len();
-        let mac_addr_ptr = if mac_addr_len > 0 { mac_addr.as_ptr() } else { ptr::null() as *const u8 };
-        let sec_params_ptr: *const SlSecParams = sec_params.as_ref().map(|r| r as *const SlSecParams).unwrap_or(ptr::null() as *const SlSecParams);
-        let sec_params_ext_ptr: *const SlSecParamsExt = sec_params_ext.as_ref().map(|r| r as *const SlSecParamsExt).unwrap_or(ptr::null() as *const SlSecParamsExt);
+        let mac_addr_ptr = if mac_addr_len > 0 { mac_addr.as_ptr() } else { ptr::null() };
+        let sec_params_ptr = sec_params.as_ref().map(|r| r as *const SlSecParams).unwrap_or(ptr::null());
+        let sec_params_ext_ptr = sec_params_ext.as_ref().map(|r| r as *const SlSecParamsExt).unwrap_or(ptr::null());
         try_wlan!(sl_WlanConnect(ssid_ptr, ssid_len, mac_addr_ptr, sec_params_ptr, sec_params_ext_ptr));
         Ok(())
     }


### PR DESCRIPTION
When you call Option<T>::map() it creates copy of the object that
Option is wrapping. So if you take a reference of that you're
getting a reference to a temporary object. Calling Option<T>::as_ref()
gives you an Option<&T>, i.e. a reference directly to the object
contained in the Option, and when you call .map() on that it makes
a copy of the reference, which doesn't introduce a temporary.