### PR TITLE
Provide __aeabi_memclr4()

### DIFF
--- a/cc3200-sys/aeabi.c
+++ b/cc3200-sys/aeabi.c
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * Implements the ARM Run-time ABI, see
+ *
+ *   http://infocenter.arm.com/help/topic/com.arm.doc.ihi0043d/IHI0043D_rtabi.pdf
+ */
+
+#include <string.h>
+
+void __aeabi_memclr4(void* dest, size_t n)
+{
+    memset(dest, 0, n);
+}

--- a/cc3200-sys/build.rs
+++ b/cc3200-sys/build.rs
@@ -12,6 +12,7 @@ fn main() {
         .include("sdk/simplelink_extlib/provisioninglib")
         .include("sdk/third_party/FreeRTOS/source/include")
         .include("sdk/third_party/FreeRTOS/source/portable/GCC/ARM_CM4")
+        .file("aeabi.c")
         .file("board.c")
         .file("simplelink.c")
         .file("StrPrintf.c")


### PR DESCRIPTION
This patch adds the function __aeabi_memclr4(), which is requried by
core::fmt::num::GenericRadix::fmt_int<core::fmt::num::UpperHex,u32>.