### PR TITLE
Remove useless mod declaration that breaks importing crates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ openocd.log
 firmware.map
 Cargo.lock
 *.bk
-src/config.rs
+examples/config.rs

--- a/examples/config.rs.sample
+++ b/examples/config.rs.sample
@@ -1,4 +1,4 @@
-use simplelink::SlSecParams;
+use cc3200::simplelink::SlSecParams;
 
 // Eg. OpenWireless.org
 pub const SSID: &'static str = "OpenWireless.org";

--- a/examples/http.rs
+++ b/examples/http.rs
@@ -25,7 +25,6 @@ extern crate log;
 #[macro_use]
 extern crate collections;
 
-use cc3200::config;
 use cc3200::cc3200::{Board, I2C, I2COpenMode, LedEnum, LedName};
 use cc3200::simplelink::{self, NetConfigSet, Policy, SimpleLink, SimpleLinkError, WlanConfig,
                          WlanMode, WlanRxFilterOp, WlanRxFilterOpBuf};
@@ -37,6 +36,8 @@ use cc3200::tmp006::TMP006;
 use freertos_rs::{CurrentTask, Duration, Task};
 use smallhttp::Client;
 use smallhttp::traits::Channel;
+
+mod config;
 
 static VERSION: &'static str = "1.0";
 

--- a/examples/wlan_station.rs
+++ b/examples/wlan_station.rs
@@ -25,13 +25,14 @@ extern crate collections;
 
 use core::str;
 
-use cc3200::config;
 use cc3200::cc3200::{Board, LedEnum, LedName};
 use cc3200::simplelink::{self, NetConfigSet, Policy, SimpleLink, SimpleLinkError, SocketFamily,
                          WlanConfig, WlanMode, WlanRxFilterOp, WlanRxFilterOpBuf};
 use cc3200::format;
 
 use freertos_rs::{CurrentTask, Duration, Task};
+
+mod config;
 
 static VERSION: &'static str = "1.0";
 static HOST_NAME: &'static str = "www.ti.com";

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -12,7 +12,7 @@ xargo --version
 rustc --version
 arm-none-eabi-gcc --version
 
-cp src/config.rs.sample src/config.rs
+cp examples/config.rs.sample examples/config.rs
 
 for example_file in examples/*.rs; do
     example=$(basename ${example_file/.rs/})

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,6 @@ pub mod tmp006;
 pub mod rtc;
 pub mod simplelink;
 pub mod socket_channel;
-pub mod config; // SSID and password currently set here
 
 // We need to make sure that we pull in soft float versions of libm.a, libc.a
 // and libgcc.a. The build.rs sets up the paths needed for these.


### PR DESCRIPTION
If we keep that, a crate depending on cc3200-rs fails to build because it can't provide the cc3200-rs local config.rs