### PR TITLE
Force to use xargo v0.3.4

### DIFF
--- a/Xargo.toml
+++ b/Xargo.toml
@@ -1,0 +1,1 @@
+[dependencies.collections]

--- a/cc3200-sys/board.c
+++ b/cc3200-sys/board.c
@@ -216,29 +216,6 @@ vApplicationIdleHook( void)
     //Handle Idle Hook for Profiling, Power Management etc
 }
 
-void *memset(void *s, int c, size_t n) {
-    if (c == 0 && ((uintptr_t)s & 3) == 0) {
-        // aligned store of 0
-        uint32_t *s32 = s;
-        for (size_t i = n >> 2; i > 0; i--) {
-            *s32++ = 0;
-        }
-        if (n & 2) {
-            *((uint16_t*)s32) = 0;
-            s32 = (uint32_t*)((uint16_t*)s32 + 1);
-        }
-        if (n & 1) {
-            *((uint8_t*)s32) = 0;
-        }
-    } else {
-        uint8_t *s2 = s;
-        for (; n > 0; n--) {
-            *s2++ = c;
-        }
-    }
-    return s;
-}
-
 static char *fmt_hex(uint32_t val, char *buf) {
     const char *hexDig = "0123456789abcdef";
 

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -4,9 +4,9 @@ curl https://sh.rustup.rs -sSf -o rustup.sh
 chmod +x ./rustup.sh
 ./rustup.sh -y
 export PATH=/home/travis/.cargo/bin:$PATH
-rustup override set nightly-2016-11-06
+rustup override set nightly-2017-01-18
 rustup component add rust-src
-cargo install --vers 0.2 xargo
+cargo install --vers 0.3.4 xargo
 cargo --version
 xargo --version
 rustc --version

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -6,7 +6,7 @@ chmod +x ./rustup.sh
 export PATH=/home/travis/.cargo/bin:$PATH
 rustup override set nightly-2016-11-06
 rustup component add rust-src
-cargo install xargo
+cargo install --vers 0.2 xargo
 cargo --version
 xargo --version
 rustc --version


### PR DESCRIPTION
Because builds are broken with xargo 0.3.x, see https://travis-ci.org/fabricedesre/cc3200-rs/builds/192667321