### PR TITLE
Add udev rules

### DIFF
--- a/49-cc3200.rules
+++ b/49-cc3200.rules
@@ -1,0 +1,4 @@
+# Setup the FTDI chip on the cc3200 boards.
+ATTRS{idVendor}=="0451", ATTRS{idProduct}=="c32a", ENV{ID_MM_DEVICE_IGNORE}="1"
+ATTRS{idVendor}=="0451", ATTRS{idProduct}=="c32a", ENV{MTP_NO_PROBE}="1"
+ATTRS{idVendor}=="0451", ATTRS{idProduct}=="c32a", MODE="0666", GROUP="dialout", RUN+="/sbin/modprobe ftdi-sio", RUN+="/bin/sh -c '/bin/echo 0451 c32a > /sys/bus/usb-serial/drivers/ftdi_sio/new_id'"


### PR DESCRIPTION
This should also keep modemmanager from opening the device.